### PR TITLE
Relative movement implementation

### DIFF
--- a/dynamixel_controllers/CMakeLists.txt
+++ b/dynamixel_controllers/CMakeLists.txt
@@ -10,6 +10,7 @@ add_service_files(
   SetCompliancePunch.srv
   SetComplianceSlope.srv
   SetPosition.srv
+  SetRelativePosition.srv
   SetSpeed.srv
   SetSpeedandPosition.srv
   SetTorqueLimit.srv

--- a/dynamixel_controllers/src/dynamixel_controllers/joint_controller.py
+++ b/dynamixel_controllers/src/dynamixel_controllers/joint_controller.py
@@ -48,6 +48,7 @@ import rospy
 from dynamixel_driver.dynamixel_const import *
 
 from dynamixel_controllers.srv import SetPosition
+from dynamixel_controllers.srv import SetRelativePosition
 from dynamixel_controllers.srv import SetSpeed
 from dynamixel_controllers.srv import SetSpeedandPosition
 from dynamixel_controllers.srv import TorqueEnable
@@ -77,6 +78,7 @@ class JointController:
         
         self.speed_service = rospy.Service(self.controller_namespace + '/set_speed', SetSpeed, self.process_set_speed)
         self.position_service = rospy.Service(self.controller_namespace + '/set_position', SetPosition, self.process_set_position)
+        self.relative_position_service = rospy.Service(self.controller_namespace + '/set_relative_position', SetRelativePosition, self.process_set_relative_position)
         self.speed_position_service = rospy.Service(self.controller_namespace + '/set_speed_and_position', SetSpeedandPosition, self.process_set_speed_and_position)
         self.torque_service = rospy.Service(self.controller_namespace + '/torque_enable', TorqueEnable, self.process_torque_enable)
         self.compliance_slope_service = rospy.Service(self.controller_namespace + '/set_compliance_slope', SetComplianceSlope, self.process_set_compliance_slope)
@@ -132,6 +134,9 @@ class JointController:
     def set_position(self, position):
         raise NotImplementedError
 
+    def set_relative_position(self, position):
+        raise NotImplementedError
+
     def set_compliance_slope(self, slope):
         raise NotImplementedError
 
@@ -154,6 +159,9 @@ class JointController:
 
     def process_set_position(self, req):
         return self.set_position(req.position)
+
+    def process_set_relative_position(self, req):
+        return self.set_relative_position(req.position)
 
     def process_torque_enable(self, req):
         self.set_torque_enable(req.torque_enable)

--- a/dynamixel_controllers/src/dynamixel_controllers/joint_controller.py
+++ b/dynamixel_controllers/src/dynamixel_controllers/joint_controller.py
@@ -73,9 +73,9 @@ class JointController:
         self.compliance_margin = rospy.get_param(self.controller_namespace + '/joint_compliance_margin', None)
         self.compliance_punch = rospy.get_param(self.controller_namespace + '/joint_compliance_punch', None)
         self.torque_limit = rospy.get_param(self.controller_namespace + '/joint_torque_limit', None)
-        
+
         self.__ensure_limits()
-        
+
         self.speed_service = rospy.Service(self.controller_namespace + '/set_speed', SetSpeed, self.process_set_speed)
         self.position_service = rospy.Service(self.controller_namespace + '/set_position', SetPosition, self.process_set_position)
         self.relative_position_service = rospy.Service(self.controller_namespace + '/set_relative_position', SetRelativePosition, self.process_set_relative_position)
@@ -91,17 +91,17 @@ class JointController:
             if self.compliance_slope < DXL_MIN_COMPLIANCE_SLOPE: self.compliance_slope = DXL_MIN_COMPLIANCE_SLOPE
             elif self.compliance_slope > DXL_MAX_COMPLIANCE_SLOPE: self.compliance_slope = DXL_MAX_COMPLIANCE_SLOPE
             else: self.compliance_slope = int(self.compliance_slope)
-            
+
         if self.compliance_margin is not None:
             if self.compliance_margin < DXL_MIN_COMPLIANCE_MARGIN: self.compliance_margin = DXL_MIN_COMPLIANCE_MARGIN
             elif self.compliance_margin > DXL_MAX_COMPLIANCE_MARGIN: self.compliance_margin = DXL_MAX_COMPLIANCE_MARGIN
             else: self.compliance_margin = int(self.compliance_margin)
-            
+
         if self.compliance_punch is not None:
             if self.compliance_punch < DXL_MIN_PUNCH: self.compliance_punch = DXL_MIN_PUNCH
             elif self.compliance_punch > DXL_MAX_PUNCH: self.compliance_punch = DXL_MAX_PUNCH
             else: self.compliance_punch = int(self.compliance_punch)
-            
+
         if self.torque_limit is not None:
             if self.torque_limit < 0: self.torque_limit = 0.0
             elif self.torque_limit > 1: self.torque_limit = 1.0
@@ -113,6 +113,7 @@ class JointController:
         self.running = True
         self.joint_state_pub = rospy.Publisher(self.controller_namespace + '/state', JointState, queue_size=1)
         self.command_sub = rospy.Subscriber(self.controller_namespace + '/command', Float64, self.process_command)
+        self.relative_command_sub = rospy.Subscriber(self.controller_namespace + '/relative_command', Float64, self.process_relative_command)
         self.motor_states_sub = rospy.Subscriber('motor_states/%s' % self.port_namespace, MotorStateList, self.process_motor_states)
 
     def stop(self):
@@ -189,6 +190,9 @@ class JointController:
     def process_command(self, msg):
         raise NotImplementedError
 
+    def process_relative_command(self, msg):
+        raise NotImplementedError
+
     def rad_to_raw(self, angle, initial_position_raw, flipped, encoder_ticks_per_radian):
         """ angle is in radians """
         #print 'flipped = %s, angle_in = %f, init_raw = %d' % (str(flipped), angle, initial_position_raw)
@@ -198,4 +202,3 @@ class JointController:
 
     def raw_to_rad(self, raw, initial_position_raw, flipped, radians_per_encoder_tick):
         return (initial_position_raw - raw if flipped else raw - initial_position_raw) * radians_per_encoder_tick
-

--- a/dynamixel_controllers/src/dynamixel_controllers/joint_position_controller.py
+++ b/dynamixel_controllers/src/dynamixel_controllers/joint_position_controller.py
@@ -212,8 +212,8 @@ class JointPositionController(JointController):
         angle = msg.data
         mcv = (self.motor_id, self.pos_rad_to_raw(angle))
         self.dxl_io.set_multi_position([mcv])
-goal
+
     def process_relative_command(self, msg):
         angle = self.joint_state.current_pos + msg.data
         mcv = (self.motor_id, self.pos_rad_to_raw(angle))
-        self.dcl_io.set_multi_position([mcv])
+        self.dxl_io.set_multi_position([mcv])

--- a/dynamixel_controllers/src/dynamixel_controllers/joint_position_controller.py
+++ b/dynamixel_controllers/src/dynamixel_controllers/joint_position_controller.py
@@ -137,6 +137,8 @@ class JointPositionController(JointController):
         min_max_limit_reached = False
         angle = position
         limit = 0.1
+        # for now we set the speed really high
+        self.set_speed(5.0)
         mcv = (self.motor_id, self.pos_rad_to_raw(angle))
         self.dxl_io.set_multi_position([mcv])
 
@@ -144,14 +146,19 @@ class JointPositionController(JointController):
         rospy.sleep(0.1)
 
         while self.joint_state.is_moving:
-            rospy.sleep(0.1)
+            rospy.sleep(0.01)
 
         if abs(self.joint_state.current_pos - position) < limit:
             goal_reached = True
+            return (goal_reached, min_max_limit_reached)
         if abs(self.max_angle - self.joint_state.goal_pos) < limit or \
                         abs(self.min_angle - self.joint_state.goal_pos) < limit:
             min_max_limit_reached = True
-        return (goal_reached, min_max_limit_reached)
+            return (goal_reached, min_max_limit_reached)
+
+    def set_relative_position(self, position):
+        goal = self.joint_state.current_pos + position
+        return self.set_position(goal)
 
     def set_compliance_slope(self, slope):
         if slope < DXL_MIN_COMPLIANCE_SLOPE: slope = DXL_MIN_COMPLIANCE_SLOPE

--- a/dynamixel_controllers/src/dynamixel_controllers/joint_position_controller.py
+++ b/dynamixel_controllers/src/dynamixel_controllers/joint_position_controller.py
@@ -54,7 +54,7 @@ from dynamixel_msgs.msg import JointState
 class JointPositionController(JointController):
     def __init__(self, dxl_io, controller_namespace, port_namespace):
         JointController.__init__(self, dxl_io, controller_namespace, port_namespace)
-        
+
         self.motor_id = rospy.get_param(self.controller_namespace + '/motor/id')
         self.initial_position_raw = rospy.get_param(self.controller_namespace + '/motor/init')
         self.min_angle_raw = rospy.get_param(self.controller_namespace + '/motor/min')
@@ -63,9 +63,9 @@ class JointPositionController(JointController):
             self.acceleration = rospy.get_param(self.controller_namespace + '/motor/acceleration')
         else:
             self.acceleration = None
-        
+
         self.flipped = self.min_angle_raw > self.max_angle_raw
-        
+
         self.joint_state = JointState(name=self.joint_name, motor_ids=[self.motor_id])
 
     def initialize(self):
@@ -76,23 +76,23 @@ class JointPositionController(JointController):
             rospy.logwarn('Available ids: %s' % str(available_ids))
             rospy.logwarn('Specified id: %d' % self.motor_id)
             return False
-            
+
         self.RADIANS_PER_ENCODER_TICK = rospy.get_param('dynamixel/%s/%d/radians_per_encoder_tick' % (self.port_namespace, self.motor_id))
         self.ENCODER_TICKS_PER_RADIAN = rospy.get_param('dynamixel/%s/%d/encoder_ticks_per_radian' % (self.port_namespace, self.motor_id))
-        
+
         if self.flipped:
             self.min_angle = (self.initial_position_raw - self.min_angle_raw) * self.RADIANS_PER_ENCODER_TICK
             self.max_angle = (self.initial_position_raw - self.max_angle_raw) * self.RADIANS_PER_ENCODER_TICK
         else:
             self.min_angle = (self.min_angle_raw - self.initial_position_raw) * self.RADIANS_PER_ENCODER_TICK
             self.max_angle = (self.max_angle_raw - self.initial_position_raw) * self.RADIANS_PER_ENCODER_TICK
-            
+
         self.ENCODER_RESOLUTION = rospy.get_param('dynamixel/%s/%d/encoder_resolution' % (self.port_namespace, self.motor_id))
         self.MAX_POSITION = self.ENCODER_RESOLUTION - 1
         self.VELOCITY_PER_TICK = rospy.get_param('dynamixel/%s/%d/radians_second_per_encoder_tick' % (self.port_namespace, self.motor_id))
         self.MAX_VELOCITY = rospy.get_param('dynamixel/%s/%d/max_velocity' % (self.port_namespace, self.motor_id))
         self.MIN_VELOCITY = self.VELOCITY_PER_TICK
-        
+
         if self.compliance_slope is not None: self.set_compliance_slope(self.compliance_slope)
         if self.compliance_margin is not None: self.set_compliance_margin(self.compliance_margin)
         if self.compliance_punch is not None: self.set_compliance_punch(self.compliance_punch)
@@ -102,15 +102,15 @@ class JointPositionController(JointController):
             self.dxl_io.set_acceleration(self.motor_id, self.acceleration)
 
         self.joint_max_speed = rospy.get_param(self.controller_namespace + '/joint_max_speed', self.MAX_VELOCITY)
-        
+
         if self.joint_max_speed < self.MIN_VELOCITY: self.joint_max_speed = self.MIN_VELOCITY
         elif self.joint_max_speed > self.MAX_VELOCITY: self.joint_max_speed = self.MAX_VELOCITY
-        
+
         if self.joint_speed < self.MIN_VELOCITY: self.joint_speed = self.MIN_VELOCITY
         elif self.joint_speed > self.joint_max_speed: self.joint_speed = self.joint_max_speed
-        
+
         self.set_speed(self.joint_speed)
-        
+
         return True
 
     def pos_rad_to_raw(self, pos_rad):
@@ -205,11 +205,15 @@ class JointPositionController(JointController):
                 self.joint_state.load = state.load
                 self.joint_state.is_moving = state.moving
                 self.joint_state.header.stamp = rospy.Time.from_sec(state.timestamp)
-                
+
                 self.joint_state_pub.publish(self.joint_state)
 
     def process_command(self, msg):
         angle = msg.data
         mcv = (self.motor_id, self.pos_rad_to_raw(angle))
         self.dxl_io.set_multi_position([mcv])
-
+goal
+    def process_relative_command(self, msg):
+        angle = self.joint_state.current_pos + msg.data
+        mcv = (self.motor_id, self.pos_rad_to_raw(angle))
+        self.dcl_io.set_multi_position([mcv])

--- a/dynamixel_controllers/srv/SetRelativePosition.srv
+++ b/dynamixel_controllers/srv/SetRelativePosition.srv
@@ -1,0 +1,5 @@
+float64 position
+---
+bool goal_reached
+bool min_max_limit_reached
+


### PR DESCRIPTION
We use this to fixate the camera on to a certain point in world coordinates while the robot is moving.
Both service and publisher/subscriber implementation is available. The service, however, is noticeable slower.